### PR TITLE
FIX Page now always loads on top

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ import { CSSFramework } from "./Pages/AllResources/CSSFramework";
 import Aws from "./Pages/AllResources/Aws";
 import Navbar from "./components/Navbar/Navbar";
 import Footer from "./components/Footer/Footer";
+import ScrollToTop from "./components/ScrollToTop";
 
 const Container = styled.div`
   scrollbar-width: none;
@@ -43,6 +44,7 @@ function App() {
     <>
       <Container>
         <BrowserRouter>
+        <ScrollToTop />
           <Navbar />
           <Routes>
             <Route path="/">

--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:
#214 

#example

It was always a feature of React router explained [here](https://v5.reactrouter.com/web/guides/scroll-restoration). I added a page named ScrollOnTop on the components folder and imported it on the App file

## Changes proposed

Here comes all the changes proposed through this PR
Adding a new page ScrollOnTop on components folder and importing it on App file

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x ] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.

